### PR TITLE
Wrecked airlock needed roof property as normal airlocks do.

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Salvage.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Salvage.xml
@@ -86,6 +86,7 @@
 				<isHull>true</isHull>
 				<isPlating>true</isPlating>
 				<wreckage>true</wreckage>
+				<roof>true</roof>
 			</li>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>


### PR DESCRIPTION
Not having it prevented roof removal on them when decon, and those remaining roofs were annoying.
Looks like this change is correct in terms of use of roof property in other cases.