### PR TITLE
Fix for pilot tac and science consoles having reverse chair preview when placing them. Screenhot in desc

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1321,6 +1321,7 @@
 		<altitudeLayer>Building</altitudeLayer>
 		<hasInteractionCell>True</hasInteractionCell>
 		<interactionCellOffset>(0,0,1)</interactionCellOffset>
+		<interactionCellIconReverse>true</interactionCellIconReverse>
 		<stealable>false</stealable>
 		<size>(3,1)</size>
 		<pathCost>30</pathCost>
@@ -1387,6 +1388,7 @@
 		<altitudeLayer>Building</altitudeLayer>
 		<hasInteractionCell>True</hasInteractionCell>
 		<interactionCellOffset>(0,0,1)</interactionCellOffset>
+		<interactionCellIconReverse>true</interactionCellIconReverse>
 		<stealable>false</stealable>
 		<size>(3,1)</size>
 		<pathCost>30</pathCost>
@@ -1453,6 +1455,7 @@
 		<altitudeLayer>Building</altitudeLayer>
 		<hasInteractionCell>True</hasInteractionCell>
 		<interactionCellOffset>(0,0,1)</interactionCellOffset>
+		<interactionCellIconReverse>true</interactionCellIconReverse>
 		<stealable>false</stealable>
 		<size>(3,1)</size>
 		<pathCost>30</pathCost>


### PR DESCRIPTION
![screenshot59](https://github.com/KentHaeger/SaveOurShip2/assets/167825918/ed3c7298-1f32-44aa-b136-1c41e26d3daf)
